### PR TITLE
Add localstack for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ end
 
 Documentation can be found at [https://hexdocs.pm/ex_aws_cloudwatch](https://hexdocs.pm/ex_aws_cloudwatch).
 
+## Testing
+
+### Live cloudwatch
+
+To run the tests against live cloudwatch:
+
+```
+AWS_ACCESS_KEY_ID={your-real-access-key-id} AWS_SECRET_ACCESS_KEY={your-real-secret-access-key} mix test
+```
+
+### Localstack
+
+To run the tests against localstack:
+
+First start localstack:
+
+```
+docker-compose up
+```
+
+Then run the tests:
+
+```
+AWS_ACCESS_KEY_ID='y' AWS_SECRET_ACCESS_KEY='x' MONITORING_HOST='localhost' MONITORING_SCHEME='http' MONITORING_PORT="4582"  mix test
+```
+
 ## License
 
 The MIT License (MIT)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,6 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :ex_aws_cloudwatch, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:ex_aws_cloudwatch, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+case File.stat("config/#{Mix.env}.exs") do
+  {:ok, _} -> import_config "#{Mix.env}.exs"
+  _ -> :noop
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,8 @@
+use Mix.Config
+
+{port, ""} = Integer.parse(System.get_env("MONITORING_PORT") || "443")
+
+config :ex_aws, :monitoring,
+  scheme: System.get_env("MONITORING_SCHEME") || "https",
+  host: System.get_env("MONITORING_HOST") || "monitoring.us-east-1.amazonaws.com",
+  port: port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  aws:
+    image: localstack/localstack
+    environment:
+      SERVICES: "cloudwatch"
+    ports:
+      - 4582:4582

--- a/lib/ex_aws/cloudwatch/parsers.ex
+++ b/lib/ex_aws/cloudwatch/parsers.ex
@@ -99,7 +99,7 @@ if Code.ensure_loaded?(SweetXml) do
         |> SweetXml.xpath(
           ~x"//ErrorResponse",
           code: ~x"./Error/Code/text()"s,
-          message: ~x"./Error/Message/text()"s,
+          message: ~x"./Error/Message/text()"s
         )
       {:error, Map.put(resp, :body, parsed_body)}
     end


### PR DESCRIPTION
Add localstack docker-compose to run integration tests against it.

By default it will try to hit `aws` but we allow to specify `host`, `port` & `scheme` so we can test locally.