### PR TITLE
Put multiple metric values

### DIFF
--- a/lib/ex_aws/cloudwatch.ex
+++ b/lib/ex_aws/cloudwatch.ex
@@ -30,13 +30,15 @@ defmodule ExAws.Cloudwatch do
         ]
   @type dimension :: {name :: binary | atom, value :: binary}
   @type metric_datum :: [
+          counts: [non_neg_integer],
           dimensions: [dimension, ...],
           metric_name: binary,
           statistic_values: statistic_set,
           storage_resolution: integer,
           timestamp: DateTime.t,
           unit: binary,
-          value: number
+          value: number,
+          values: [number]
         ]
   @type statistic_set :: [
           maximum: number,
@@ -624,6 +626,10 @@ defmodule ExAws.Cloudwatch do
     alarm_names |> format(prefix: "AlarmNames.member")
   end
 
+  defp format_param({:counts, counts}) do
+    counts |> format(prefix: "Counts.member")
+  end
+
   defp format_param({:dashboard_names, dashboard_names}) do
     dashboard_names |> format(prefix: "DashboardNames.member")
   end
@@ -676,6 +682,10 @@ defmodule ExAws.Cloudwatch do
     timestamp
     |> DateTime.to_iso8601()
     |> format(prefix: "Timestamp")
+  end
+
+  defp format_param({:values, values}) do
+    values |> format(prefix: "Values.member")
   end
 
   defp format_param({key, parameters}) do

--- a/lib/ex_aws/cloudwatch.ex
+++ b/lib/ex_aws/cloudwatch.ex
@@ -36,13 +36,13 @@ defmodule ExAws.Cloudwatch do
           storage_resolution: integer,
           timestamp: DateTime.t,
           unit: binary,
-          value: float
+          value: number
         ]
   @type statistic_set :: [
-          maximum: float,
-          minimum: float,
-          sample_count: float,
-          sum: float
+          maximum: number,
+          minimum: number,
+          sample_count: number,
+          sum: number
         ]
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExAws.Cloudwatch.Mixfile do
   def project do
     [
       app: :ex_aws_cloudwatch,
-      version: "2.0.3",
+      version: "2.0.4",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       start_permanent: Mix.env == :prod,

--- a/test/lib/cloudwatch_test.exs
+++ b/test/lib/cloudwatch_test.exs
@@ -10,7 +10,7 @@ defmodule ExAws.CloudwatchTest do
 
   test "#put_metric_data" do
     {:ok, timestamp, 0} = DateTime.from_iso8601("2018-06-20T02:51:43Z")
-    metric_datum = [
+    one_value_metric_datum = [
       metric_name: "My Metric Name",
       dimensions: [
         my_dim_1: "dim_1_value",
@@ -20,17 +20,44 @@ defmodule ExAws.CloudwatchTest do
       unit: "Count",
       storage_resolution: 1,
 
-      # In production, either :statistic_values or :value is required.
+      value: 1.0
+    ]
+    multiple_values_metric_datum = [
+      metric_name: "My Multi Metric Name",
+      dimensions: [
+        my_multi_dim_1: "multi_dim_1_value",
+        my_multi_dim_2: "multi_dim_2_value"
+      ],
+      timestamp: timestamp,
+      unit: "Milliseconds",
+      storage_resolution: 1,
+
+      values: [1, 2, 3.5, 4.2],
+      counts: [10, 1, 5, 188],
+    ]
+    statistics_metric_datum = [
+      metric_name: "My Statistics Metric Name",
+      dimensions: [
+        my_statistics_dim_1: "statistics_dim_1_value",
+        my_statistics_dim_2: "statistics_dim_2_value"
+      ],
+      timestamp: timestamp,
+      unit: "Count",
+      storage_resolution: 1,
+
       statistic_values: [
         maximum: 6,
         minimum: 4,
         sample_count: 3,
         sum: 15
       ],
-      value: 1.0
     ]
 
-    metric_data = [metric_datum, metric_datum, metric_datum]
+    metric_data = [
+      one_value_metric_datum,
+      multiple_values_metric_datum,
+      statistics_metric_datum
+    ]
     expected = %{
       "Action" => "PutMetricData",
       "MetricData.member.1.Dimensions.member.1.Name" => "my_dim_1",
@@ -38,32 +65,31 @@ defmodule ExAws.CloudwatchTest do
       "MetricData.member.1.Dimensions.member.2.Name" => "my_dim_2",
       "MetricData.member.1.Dimensions.member.2.Value" => "dim_2_value",
       "MetricData.member.1.MetricName" => "My Metric Name",
-      "MetricData.member.1.StatisticValues.Maximum" => 6,
-      "MetricData.member.1.StatisticValues.Minimum" => 4,
-      "MetricData.member.1.StatisticValues.SampleCount" => 3,
-      "MetricData.member.1.StatisticValues.Sum" => 15,
       "MetricData.member.1.StorageResolution" => 1,
       "MetricData.member.1.Timestamp" => "2018-06-20T02:51:43Z",
       "MetricData.member.1.Unit" => "Count",
       "MetricData.member.1.Value" => 1.0,
-      "MetricData.member.2.Dimensions.member.1.Name" => "my_dim_1",
-      "MetricData.member.2.Dimensions.member.1.Value" => "dim_1_value",
-      "MetricData.member.2.Dimensions.member.2.Name" => "my_dim_2",
-      "MetricData.member.2.Dimensions.member.2.Value" => "dim_2_value",
-      "MetricData.member.2.MetricName" => "My Metric Name",
-      "MetricData.member.2.StatisticValues.Maximum" => 6,
-      "MetricData.member.2.StatisticValues.Minimum" => 4,
-      "MetricData.member.2.StatisticValues.SampleCount" => 3,
-      "MetricData.member.2.StatisticValues.Sum" => 15,
+      "MetricData.member.2.Counts.member.1" => 10,
+      "MetricData.member.2.Counts.member.2" => 1,
+      "MetricData.member.2.Counts.member.3" => 5,
+      "MetricData.member.2.Counts.member.4" => 188,
+      "MetricData.member.2.Dimensions.member.1.Name" => "my_multi_dim_1",
+      "MetricData.member.2.Dimensions.member.1.Value" => "multi_dim_1_value",
+      "MetricData.member.2.Dimensions.member.2.Name" => "my_multi_dim_2",
+      "MetricData.member.2.Dimensions.member.2.Value" => "multi_dim_2_value",
+      "MetricData.member.2.MetricName" => "My Multi Metric Name",
       "MetricData.member.2.StorageResolution" => 1,
       "MetricData.member.2.Timestamp" => "2018-06-20T02:51:43Z",
-      "MetricData.member.2.Unit" => "Count",
-      "MetricData.member.2.Value" => 1.0,
-      "MetricData.member.3.Dimensions.member.1.Name" => "my_dim_1",
-      "MetricData.member.3.Dimensions.member.1.Value" => "dim_1_value",
-      "MetricData.member.3.Dimensions.member.2.Name" => "my_dim_2",
-      "MetricData.member.3.Dimensions.member.2.Value" => "dim_2_value",
-      "MetricData.member.3.MetricName" => "My Metric Name",
+      "MetricData.member.2.Unit" => "Milliseconds",
+      "MetricData.member.2.Values.member.1" => 1,
+      "MetricData.member.2.Values.member.2" => 2,
+      "MetricData.member.2.Values.member.3" => 3.5,
+      "MetricData.member.2.Values.member.4" => 4.2,
+      "MetricData.member.3.Dimensions.member.1.Name" => "my_statistics_dim_1",
+      "MetricData.member.3.Dimensions.member.1.Value" => "statistics_dim_1_value",
+      "MetricData.member.3.Dimensions.member.2.Name" => "my_statistics_dim_2",
+      "MetricData.member.3.Dimensions.member.2.Value" => "statistics_dim_2_value",
+      "MetricData.member.3.MetricName" => "My Statistics Metric Name",
       "MetricData.member.3.StatisticValues.Maximum" => 6,
       "MetricData.member.3.StatisticValues.Minimum" => 4,
       "MetricData.member.3.StatisticValues.SampleCount" => 3,
@@ -71,7 +97,6 @@ defmodule ExAws.CloudwatchTest do
       "MetricData.member.3.StorageResolution" => 1,
       "MetricData.member.3.Timestamp" => "2018-06-20T02:51:43Z",
       "MetricData.member.3.Unit" => "Count",
-      "MetricData.member.3.Value" => 1.0,
       "Namespace" => "My Name Space",
       "Version" => "2010-08-01",
     }


### PR DESCRIPTION
Hello!
`PutMetricData` API allows to publish arrays of values and the number of times each value occurred during the period by using the `Values` and `Counts` fields in the `MetricDatum` structure.
But now they are not formatted properly:
```
      "MetricData.member.2.Counts.1" => 10,
      "MetricData.member.2.Counts.2" => 1,
      "MetricData.member.2.Counts.3" => 5,
      "MetricData.member.2.Counts.4" => 188,
      "MetricData.member.2.Values.1" => 1,
      "MetricData.member.2.Values.2" => 2,
      "MetricData.member.2.Values.3" => 3.5,
      "MetricData.member.2.Values.4" => 4.2,
```
Instead of:
```
      "MetricData.member.2.Counts.member.1" => 10,
      "MetricData.member.2.Counts.member.2" => 1,
      "MetricData.member.2.Counts.member.3" => 5,
      "MetricData.member.2.Counts.member.4" => 188,
      "MetricData.member.2.Values.member.1" => 1,
      "MetricData.member.2.Values.member.2" => 2,
      "MetricData.member.2.Values.member.3" => 3.5,
      "MetricData.member.2.Values.member.4" => 4.2,
```