### PR TITLE
Add GetMetricWidgetImage

### DIFF
--- a/lib/ex_aws/cloudwatch.ex
+++ b/lib/ex_aws/cloudwatch.ex
@@ -590,6 +590,42 @@ defmodule ExAws.Cloudwatch do
     |> build_request(:put_metric_data)
   end
 
+  @doc """
+  Retrieves a snapshot graph of one or more Amazon CloudWatch metrics as
+  a bitmap image.
+
+  You can then embed this image into your services and products, such as
+  wiki pages, reports, and documents. You could also retrieve images
+  regularly, such as every minute, and create your own custom live
+  dashboard.
+
+  There is a limit of 20 transactions per second for this API. Each
+  GetMetricWidgetImage action has the following limits:
+
+  * As many as 100 metrics in the graph.
+  * Up to 100 KB uncompressed payload.
+
+  ## Examples:
+      iex> ExAws.Cloudwatch.get_metric_widget_image("{\"metrics\":[[\"AWS/EC2\", \"CPUUtilization\", \"InstanceId\", \"i-1234567890abcdef0\"]]}")
+      %ExAws.Operation.Query{
+        action: :get_metric_widget_image,
+        params: %{
+          "Action" => "GetMetricWidgetImage",
+          "MetricWidget" => "{\"metrics\":[[\"AWS/EC2\", \"CPUUtilization\", \"InstanceId\", \"i-1234567890abcdef0\"]]}",
+          "Version" => "2010-08-01"
+        },
+        parser: &ExAws.Cloudwatch.Parsers.parse/2,
+        path: "/",
+        service: :monitoring
+      }
+  """
+  @spec get_metric_widget_image(metric_widget :: binary) ::
+          ExAws.Operation.Query.t()
+  def get_metric_widget_image(metric_widget) do
+    [{:metric_widget, metric_widget}]
+    |> build_request(:get_metric_widget_image)
+  end
+
   ####################
   # Helper Functions #
   ####################

--- a/lib/ex_aws/cloudwatch/parsers.ex
+++ b/lib/ex_aws/cloudwatch/parsers.ex
@@ -104,6 +104,18 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, Map.put(resp, :body, parsed_body)}
     end
 
+    def parse({:ok, %{body: xml} = resp}, :get_metric_widget_image) do
+      parsed_body =
+        xml
+        |> SweetXml.xpath(
+             ~x"//GetMetricWidgetImageResponse",
+             metric_widget_image: ~x"./GetMetricWidgetImageResult/MetricWidgetImage/text()"s,
+             request_id: ~x"./ResponseMetadata/RequestId/text()"s
+           )
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
     def parse({:error, %{body: xml} = resp}, _) do
       parsed_body = 
         xml

--- a/test/lib/cloudwatch/integration_test.exs
+++ b/test/lib/cloudwatch/integration_test.exs
@@ -30,4 +30,16 @@ defmodule ExAws.Cloudwatch.IntegrationTest do
     {:ok, %{body: %{metrics: metrics}}} = ExAws.Cloudwatch.list_metrics() |> ExAws.request()
     assert is_list(metrics)
   end
+
+  test "check get_metric_widget_image is successful" do
+    metric_widget = %{
+      metrics: [
+        ["EC2", "CPUUtilization", "InstanceId", "i-a1b2c3d4"]
+      ]
+    } |> Poison.encode!
+    {:ok, result} = metric_widget
+                    |> ExAws.Cloudwatch.get_metric_widget_image()
+                    |> ExAws.request()
+    assert %{body: %{request_id: _, metric_widget_image: _}} = result
+  end
 end

--- a/test/lib/cloudwatch/parser_test.exs
+++ b/test/lib/cloudwatch/parser_test.exs
@@ -85,4 +85,23 @@ defmodule ExAws.Cloudwatch.ParserTest do
 
     assert alarm[:dimensions] == [%{name: "dimension-name", value: "dimension-value"}]
   end
+
+  test "#parsing a get_metric_widget_image response" do
+    rsp = """
+      <GetMetricWidgetImageResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
+        <GetMetricWidgetImageResult>
+          <MetricWidgetImage>iVBORw0KGgoAAAANSUhEUgAAAlgAAAGQEAYAAAAip...</MetricWidgetImage>
+        </GetMetricWidgetImageResult>
+        <ResponseMetadata>
+          <RequestId>6f0d4192-4d42-11e8-82c1-f539a07e0e3b</RequestId>
+        </ResponseMetadata>
+      </GetMetricWidgetImageResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :get_metric_widget_image)
+
+    assert parsed_doc[:metric_widget_image] == "iVBORw0KGgoAAAANSUhEUgAAAlgAAAGQEAYAAAAip..."
+    assert parsed_doc[:request_id] == "6f0d4192-4d42-11e8-82c1-f539a07e0e3b"
+  end
 end


### PR DESCRIPTION
This PR should add [GetMetricWidgetImage](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricWidgetImage.html).

It seems that this API call is not implemented in localstack. You should use your access key to test.