### PR TITLE
Fixed parser error on get metric statistics

### DIFF
--- a/lib/ex_aws/cloudwatch/parsers.ex
+++ b/lib/ex_aws/cloudwatch/parsers.ex
@@ -6,11 +6,11 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//DescribeAlarmsResponse",
-             alarms: alarm_xml_description(),
-             next_token: ~x"./DescribeAlarmsResult/NextToken/text()"s,
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//DescribeAlarmsResponse",
+          alarms: alarm_xml_description(),
+          next_token: ~x"./DescribeAlarmsResult/NextToken/text()"s,
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -19,11 +19,11 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//DescribeAlarmHistoryResponse",
-             alarm_history: alarm_history_xml_description(),
-             next_token: ~x"./DescribeAlarmHistoryResult/NextToken/text()"s,
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//DescribeAlarmHistoryResponse",
+          alarm_history: alarm_history_xml_description(),
+          next_token: ~x"./DescribeAlarmHistoryResult/NextToken/text()"s,
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -32,12 +32,12 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//GetDashboardResponse",
-             dashboard_arn: ~x"./GetDashboardResult/DashboardArn/text()"s,
-             dashboard_body: ~x"./GetDashboardResult/DashboardBody/text()"s,
-             dashboard_name: ~x"./GetDashboardResult/DashboardName/text()"s,
-             request_id: ~x"./ResponseMetadata/ReqeustId/text()"s
-           )
+          ~x"//GetDashboardResponse",
+          dashboard_arn: ~x"./GetDashboardResult/DashboardArn/text()"s,
+          dashboard_body: ~x"./GetDashboardResult/DashboardBody/text()"s,
+          dashboard_name: ~x"./GetDashboardResult/DashboardName/text()"s,
+          request_id: ~x"./ResponseMetadata/ReqeustId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -46,11 +46,11 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//GetMetricStatisticsResponse",
-             metric_statistics: metric_statistics_description(),
-             label: ~x"./GetMetricStatisticsResult/Label/text()"s,
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//GetMetricStatisticsResponse",
+          metric_statistics: metric_statistics_description(),
+          label: ~x"./GetMetricStatisticsResult/Label/text()"s,
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -59,11 +59,11 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//ListDashboardsResponse",
-             dashboards: dashboards_description(),
-             next_token: ~x"./ListDashboardsResult/NextToken/text()"s,
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//ListDashboardsResponse",
+          dashboards: dashboards_description(),
+          next_token: ~x"./ListDashboardsResult/NextToken/text()"s,
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -72,11 +72,11 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//ListMetricsResponse",
-             metrics: metrics_description(),
-             next_token: ~x"./ListMetricsResult/NextToken/text()"s,
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//ListMetricsResponse",
+          metrics: metrics_description(),
+          next_token: ~x"./ListMetricsResult/NextToken/text()"s,
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -85,10 +85,10 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//PutDashboardResponse",
-             dashboard_messages: dashboard_messages_description(),
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//PutDashboardResponse",
+          dashboard_messages: dashboard_messages_description(),
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -97,21 +97,22 @@ if Code.ensure_loaded?(SweetXml) do
       parsed_body =
         xml
         |> SweetXml.xpath(
-             ~x"//PutMetricDataResponse",
-             request_id: ~x"./ResponseMetadata/RequestId/text()"s
-           )
+          ~x"//PutMetricDataResponse",
+          request_id: ~x"./ResponseMetadata/RequestId/text()"s
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
 
     def parse({:error, %{body: xml} = resp}, _) do
-      parsed_body = 
+      parsed_body =
         xml
         |> SweetXml.xpath(
           ~x"//ErrorResponse",
           code: ~x"./Error/Code/text()"s,
           message: ~x"./Error/Message/text()"s
         )
+
       {:error, Map.put(resp, :body, parsed_body)}
     end
 
@@ -161,13 +162,13 @@ if Code.ensure_loaded?(SweetXml) do
     defp metric_statistics_description do
       [
         ~x"./GetMetricStatisticsResult/Datapoints/member"l,
-        average: ~x"./Average/text()"f,
+        average: ~x"./Average/text()"of,
         # TODO probably fix this
         extended_statistics: ~x"./ExtendedStatistics/text()"m,
-        maximum: ~x"./Maximum/text()"f,
-        minimum: ~x"./Minimum/text()"f,
-        sample_count: ~x"./SampleCount/text()"f,
-        sum: ~x"./Sum/text()"f,
+        maximum: ~x"./Maximum/text()"of,
+        minimum: ~x"./Minimum/text()"of,
+        sample_count: ~x"./SampleCount/text()"of,
+        sum: ~x"./Sum/text()"of,
         timestamp: ~x"./Timestamp/text()"s,
         unit: ~x"./Unit/text()"s
       ]

--- a/test/lib/cloudwatch/parser_test.exs
+++ b/test/lib/cloudwatch/parser_test.exs
@@ -8,52 +8,53 @@ defmodule ExAws.Cloudwatch.ParserTest do
   alias ExAws.Cloudwatch.Parsers
 
   test "#parsing a describe_alarms response" do
-    rsp = """
-      <DescribeAlarmsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
-        <DescribeAlarmsResult>
-          <NextToken>next-token</NextToken>
-          <MetricAlarms>
-            <member>
-              <MetricName>metric-name</MetricName>
-              <AlarmConfigurationUpdatedTimestamp>2017-01-01T01:01:01.000Z</AlarmConfigurationUpdatedTimestamp>
-              <StateValue>OK</StateValue>
-              <Threshold>2.0</Threshold>
-              <StateReason>a-state-reason</StateReason>
-              <InsufficientDataActions>
-                <member>a</member>
-              </InsufficientDataActions>
-              <AlarmDescription>alarm-description</AlarmDescription>
-              <AlarmActions>
-                <member>c</member>
-              </AlarmActions>
-              <StateUpdatedTimestamp>2017-01-01T00:00:00.000Z</StateUpdatedTimestamp>
-              <Period>20</Period>
-              <Statistic>Sum</Statistic>
-              <ComparisonOperator>LessThanThreshold</ComparisonOperator>
-              <AlarmName>alarm-name</AlarmName>
-              <EvaluationPeriods>1</EvaluationPeriods>
-              <StateReasonData>some-state-reason-data</StateReasonData>
-              <ActionsEnabled>true</ActionsEnabled>
-              <Namespace>a-namespace</Namespace>
-              <OKActions>
-                <member>b</member>
-              </OKActions>
-              <AlarmArn>alarm-arn</AlarmArn>
-              <Dimensions>
-                <member>
-                  <Name>dimension-name</Name>
-                  <Value>dimension-value</Value>
-                </member>
-              </Dimensions>
-            </member>
-          </MetricAlarms>
-        </DescribeAlarmsResult>
-        <ResponseMetadata>
-          <RequestId>3f1478c7-33a9-11df-9540-99d0768312d3</RequestId>
-        </ResponseMetadata>
-      </DescribeAlarmsResponse>
-    """
-    |> to_success
+    rsp =
+      """
+        <DescribeAlarmsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
+          <DescribeAlarmsResult>
+            <NextToken>next-token</NextToken>
+            <MetricAlarms>
+              <member>
+                <MetricName>metric-name</MetricName>
+                <AlarmConfigurationUpdatedTimestamp>2017-01-01T01:01:01.000Z</AlarmConfigurationUpdatedTimestamp>
+                <StateValue>OK</StateValue>
+                <Threshold>2.0</Threshold>
+                <StateReason>a-state-reason</StateReason>
+                <InsufficientDataActions>
+                  <member>a</member>
+                </InsufficientDataActions>
+                <AlarmDescription>alarm-description</AlarmDescription>
+                <AlarmActions>
+                  <member>c</member>
+                </AlarmActions>
+                <StateUpdatedTimestamp>2017-01-01T00:00:00.000Z</StateUpdatedTimestamp>
+                <Period>20</Period>
+                <Statistic>Sum</Statistic>
+                <ComparisonOperator>LessThanThreshold</ComparisonOperator>
+                <AlarmName>alarm-name</AlarmName>
+                <EvaluationPeriods>1</EvaluationPeriods>
+                <StateReasonData>some-state-reason-data</StateReasonData>
+                <ActionsEnabled>true</ActionsEnabled>
+                <Namespace>a-namespace</Namespace>
+                <OKActions>
+                  <member>b</member>
+                </OKActions>
+                <AlarmArn>alarm-arn</AlarmArn>
+                <Dimensions>
+                  <member>
+                    <Name>dimension-name</Name>
+                    <Value>dimension-value</Value>
+                  </member>
+                </Dimensions>
+              </member>
+            </MetricAlarms>
+          </DescribeAlarmsResult>
+          <ResponseMetadata>
+            <RequestId>3f1478c7-33a9-11df-9540-99d0768312d3</RequestId>
+          </ResponseMetadata>
+        </DescribeAlarmsResponse>
+      """
+      |> to_success
 
     {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :describe_alarms)
 
@@ -84,5 +85,23 @@ defmodule ExAws.Cloudwatch.ParserTest do
     assert alarm[:alarm_configuration_updated_timestamp] == "2017-01-01T01:01:01.000Z"
 
     assert alarm[:dimensions] == [%{name: "dimension-name", value: "dimension-value"}]
+  end
+
+  test "parsing a get metric statistics response" do
+    rsp =
+      "<GetMetricStatisticsResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\">\n  <GetMetricStatisticsResult>\n    <Datapoints>\n      <member>\n        <Average>0.016666666666666666</Average>\n        <Unit>Percent</Unit>\n        <Timestamp>2019-07-16T15:54:00Z</Timestamp>\n      </member>\n      <member>\n        <Average>0.0</Average>\n        <Unit>Percent</Unit>\n        <Timestamp>2019-07-16T18:54:00Z</Timestamp>\n      </member>\n      <member>\n        <Average>0.0</Average>\n        <Unit>Percent</Unit>\n        <Timestamp>2019-07-16T13:54:00Z</Timestamp>\n      </member>\n      <member>\n        <Average>0.0</Average>\n        <Unit>Percent</Unit>\n        <Timestamp>2019-07-16T00:54:00Z</Timestamp>\n      </member>\n      </Datapoints>\n    <Label>CPUUtilization</Label>\n  </GetMetricStatisticsResult>\n  <ResponseMetadata>\n    <RequestId>aba280d4-ac9c-11e9-b6ee-ff0676301ff5</RequestId>\n  </ResponseMetadata>\n</GetMetricStatisticsResponse>\n"
+      |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :get_metric_statistics)
+
+    assert Enum.count(parsed_doc[:metric_statistics]) == 4
+
+    assert parsed_doc[:label] == "CPUUtilization"
+    assert parsed_doc[:request_id] == "aba280d4-ac9c-11e9-b6ee-ff0676301ff5"
+
+    stat = parsed_doc[:metric_statistics] |> List.first()
+
+    assert stat[:average] == 0.016666666666666666
+    assert stat[:maximum] == nil
   end
 end


### PR DESCRIPTION
Basically parser logic will not break if certain optional statistic types are not included e.g. Average, Max, Min, etc..  Added a unit test

See issue: https://github.com/ex-aws/ex_aws_cloudwatch/issues/18

Note: Looks like this base repo doesn't use a .formatter.exs or wasn't run against mix format