### PR TITLE
use soft floats for potentially-missing stats

### DIFF
--- a/lib/ex_aws/cloudwatch/parsers.ex
+++ b/lib/ex_aws/cloudwatch/parsers.ex
@@ -161,13 +161,13 @@ if Code.ensure_loaded?(SweetXml) do
     defp metric_statistics_description do
       [
         ~x"./GetMetricStatisticsResult/Datapoints/member"l,
-        average: ~x"./Average/text()"f,
+        average: ~x"./Average/text()"F,
         # TODO probably fix this
         extended_statistics: ~x"./ExtendedStatistics/text()"m,
-        maximum: ~x"./Maximum/text()"f,
-        minimum: ~x"./Minimum/text()"f,
-        sample_count: ~x"./SampleCount/text()"f,
-        sum: ~x"./Sum/text()"f,
+        maximum: ~x"./Maximum/text()"F,
+        minimum: ~x"./Minimum/text()"F,
+        sample_count: ~x"./SampleCount/text()"F,
+        sum: ~x"./Sum/text()"F,
         timestamp: ~x"./Timestamp/text()"s,
         unit: ~x"./Unit/text()"s
       ]


### PR DESCRIPTION
Hi! Thanks for this repo!

I'm not entirely sure if this is correct, but without this change my application raises on parse of an empty string to a hard float. Switching to soft/nullable floats resolves this issue.